### PR TITLE
Support for Bevy 0.19

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,36 +46,37 @@
   #=== GAME ENGINE SOURCE === #
 
   ## GAME ENGINE
-  bevy_app           = { version = "0.18", default-features = false }
-  bevy_asset         = { version = "0.18", default-features = false }
-  bevy_camera        = { version = "0.18", default-features = false }
-  bevy_color         = { version = "0.18", default-features = false }
-  bevy_derive        = { version = "0.18", default-features = false }
-  bevy_ecs           = { version = "0.18", default-features = false }
-  bevy_gizmos        = { version = "0.18", default-features = false }
-  bevy_image         = { version = "0.18", default-features = false }
-  bevy_input         = { version = "0.18", default-features = false }
-  bevy_log           = { version = "0.18", default-features = false }
-  bevy_math          = { version = "0.18", default-features = false }
-  bevy_mesh          = { version = "0.18", default-features = false }
-  bevy_pbr           = { version = "0.18", default-features = false }
-  bevy_picking       = { version = "0.18", default-features = false }
-  bevy_platform      = { version = "0.18", default-features = false }
-  bevy_reflect       = { version = "0.18", default-features = false, features = ["functions"] }
-  bevy_render        = { version = "0.18", default-features = false }
-  bevy_sprite        = { version = "0.18", default-features = false, features = ["bevy_text"] }
-  bevy_sprite_render = { version = "0.18", default-features = false }
-  bevy_text          = { version = "0.18", default-features = false }
-  bevy_time          = { version = "0.18", default-features = false }
-  bevy_transform     = { version = "0.18", default-features = false }
-  bevy_window        = { version = "0.18", default-features = false }
-  bevy_winit         = { version = "0.18", default-features = false, features = ["custom_cursor"] }
-  cosmic-text        = { version = "0.16", features = ["shape-run-cache"] }
+  bevy_app           = { version = "0.19", default-features = false }
+  bevy_asset         = { version = "0.19", default-features = false }
+  bevy_camera        = { version = "0.19", default-features = false }
+  bevy_color         = { version = "0.19", default-features = false }
+  bevy_derive        = { version = "0.19", default-features = false }
+  bevy_ecs           = { version = "0.19", default-features = false }
+  bevy_gizmos        = { version = "0.19", default-features = false }
+  bevy_image         = { version = "0.19", default-features = false }
+  bevy_input         = { version = "0.19", default-features = false }
+  bevy_log           = { version = "0.19", default-features = false }
+  bevy_math          = { version = "0.19", default-features = false }
+  bevy_mesh          = { version = "0.19", default-features = false }
+  bevy_pbr           = { version = "0.19", default-features = false }
+  bevy_picking       = { version = "0.19", default-features = false }
+  bevy_platform      = { version = "0.19", default-features = false }
+  bevy_reflect       = { version = "0.19", default-features = false, features = ["functions"] }
+  bevy_render        = { version = "0.19", default-features = false }
+  bevy_sprite        = { version = "0.19", default-features = false, features = ["bevy_text"] }
+  bevy_sprite_render = { version = "0.19", default-features = false }
+  bevy_text          = { version = "0.19", default-features = false }
+  bevy_time          = { version = "0.19", default-features = false }
+  bevy_transform     = { version = "0.19", default-features = false }
+  bevy_window        = { version = "0.19", default-features = false }
+  bevy_winit         = { version = "0.19", default-features = false, features = ["custom_cursor"] }
 
   #===============================#
   #=== GAME ENGINE EXTENSIONS === #
 
-  bevy_rich_text3d = { version = "^0.6" }
+  # Bevy 0.19 port from mintlu8/bevy_rich_text3d#23. Pin the exact
+  # reviewed commit so builds do not drift as the contributor branch moves.
+  bevy_rich_text3d = { git = "https://github.com/mintlu8/bevy_rich_text3d", rev = "1ee4f06046a1cad2e5fca9af2fc826c68ef1aec0" }
 
   #===========================#
   #=== RUST MISCELLANEOUS === #

--- a/crate/Cargo.toml
+++ b/crate/Cargo.toml
@@ -42,7 +42,6 @@
   bevy_transform     = { workspace = true }
   bevy_window        = { workspace = true }
   bevy_winit         = { workspace = true }
-  cosmic-text        = { workspace = true }
 
   # GAME ENGINE EXTENSIONS
   bevy_rich_text3d = { workspace = true, optional = true }

--- a/crate/src/lib.rs
+++ b/crate/src/lib.rs
@@ -130,7 +130,7 @@ pub fn system_embedd_resize(
     mut images: ResMut<Assets<Image>>,
 ) {
     for (sprite, dimension) in &query {
-        if let Some(image) = images.get_mut(&sprite.image) && **dimension != Vec2::ZERO {
+        if let Some(mut image) = images.get_mut(&sprite.image) && **dimension != Vec2::ZERO {
             image.resize(bevy_render::render_resource::Extent3d { width: dimension.x as u32, height: dimension.y as u32, ..Default::default() });
         }
     }
@@ -826,15 +826,15 @@ pub fn system_image_size_to_layout(
 /// # )).with_children(|ui| {
 ///       ui.spawn((
 ///           // Position the text using the window layout's position and anchor
-///           UiLayout::window().pos((Rh(40.0), Rl(50.0))).anchor(Anchor::CenterLeft).pack(),
+///           UiLayout::window().pos((Rh(40.0), Rl(50.0))).anchor(Anchor::CENTER_LEFT).pack(),
 ///           // This controls the height of the text, so 60% of the parent's node height
 ///           UiTextSize::from(Rh(60.0)),
 ///           // You can attach text like this
 ///           Text2d::new("Button"),
 ///           // Font size now works as "text resolution"
 ///           TextFont {
-///               font: asset_server.load("fonts/Rajdhani.ttf"),
-///               font_size: 64.0,
+///               font: asset_server.load("fonts/Rajdhani.ttf").into(),
+///               font_size: FontSize::Px(64.0),
 ///               ..Default::default()
 ///           },
 ///       ));
@@ -1162,10 +1162,10 @@ pub fn system_color(
             **text = blend_color.into();
         }
         if let Some(id) = mat2d {
-            if let Some(mat) = materials2d.get_mut(id) {
+            if let Some(mut mat) = materials2d.get_mut(id) {
                 mat.color = blend_color.into();
             }
-        } else if let Some(id) = mat3d && let Some(materials3d) = &mut materials3d && let Some(mat) = materials3d.get_mut(id) {
+        } else if let Some(id) = mat3d && let Some(materials3d) = &mut materials3d && let Some(mut mat) = materials3d.get_mut(id) {
             mat.base_color = blend_color.into();
         }
     }

--- a/examples/color2d/Cargo.toml
+++ b/examples/color2d/Cargo.toml
@@ -12,5 +12,5 @@
   #=== DEPENDENCIES & FEATURES ===#
 
 [dependencies]
-  bevy       = { version = "0.18", default-features = true }
+  bevy       = { version = "0.19", default-features = true }
   bevy_lunex = { workspace = true }

--- a/examples/dualcamera/Cargo.toml
+++ b/examples/dualcamera/Cargo.toml
@@ -12,5 +12,5 @@
   #=== DEPENDENCIES & FEATURES ===#
 
 [dependencies]
-  bevy       = { version = "0.18", default-features = true }
+  bevy       = { version = "0.19", default-features = true }
   bevy_lunex = { workspace = true }

--- a/examples/dualcamera/src/main.rs
+++ b/examples/dualcamera/src/main.rs
@@ -83,7 +83,7 @@ fn spawn_scene(
     // light
     commands.spawn((
         PointLight {
-            shadows_enabled: true,
+            shadow_maps_enabled: true,
             ..default()
         },
         Transform::from_xyz(4.0, 8.0, 4.0),

--- a/examples/hud/Cargo.toml
+++ b/examples/hud/Cargo.toml
@@ -12,5 +12,5 @@
   #=== DEPENDENCIES & FEATURES ===#
 
 [dependencies]
-  bevy       = { version = "0.18", default-features = true }
+  bevy       = { version = "0.19", default-features = true }
   bevy_lunex = { workspace = true }

--- a/examples/hud/src/main.rs
+++ b/examples/hud/src/main.rs
@@ -38,7 +38,7 @@ fn setup(
     // Light
     commands.spawn((
         PointLight {
-            shadows_enabled: true,
+            shadow_maps_enabled: true,
             ..default()
         },
         Transform::from_xyz(4.0, 8.0, 4.0),

--- a/examples/mesh2d/Cargo.toml
+++ b/examples/mesh2d/Cargo.toml
@@ -12,5 +12,5 @@
   #=== DEPENDENCIES & FEATURES ===#
 
 [dependencies]
-  bevy       = { version = "0.18", default-features = true }
+  bevy       = { version = "0.19", default-features = true }
   bevy_lunex = { workspace = true }

--- a/examples/pixelated_dualcamera/Cargo.toml
+++ b/examples/pixelated_dualcamera/Cargo.toml
@@ -12,5 +12,5 @@
   #=== DEPENDENCIES & FEATURES ===#
 
 [dependencies]
-  bevy       = { version = "0.18", default-features = true }
+  bevy       = { version = "0.19", default-features = true }
   bevy_lunex = { workspace = true }

--- a/examples/pixelated_dualcamera/src/main.rs
+++ b/examples/pixelated_dualcamera/src/main.rs
@@ -87,7 +87,7 @@ fn spawn_scene(
     // light
     commands.spawn((
         PointLight {
-            shadows_enabled: true,
+            shadow_maps_enabled: true,
             ..default()
         },
         Transform::from_xyz(4.0, 8.0, 4.0),

--- a/examples/sprite2d/Cargo.toml
+++ b/examples/sprite2d/Cargo.toml
@@ -12,5 +12,5 @@
   #=== DEPENDENCIES & FEATURES ===#
 
 [dependencies]
-  bevy       = { version = "0.18", default-features = true }
+  bevy       = { version = "0.19", default-features = true }
   bevy_lunex = { workspace = true }

--- a/examples/sprite3d/Cargo.toml
+++ b/examples/sprite3d/Cargo.toml
@@ -12,5 +12,5 @@
   #=== DEPENDENCIES & FEATURES ===#
 
 [dependencies]
-  bevy       = { version = "0.18", default-features = true }
+  bevy       = { version = "0.19", default-features = true }
   bevy_lunex = { workspace = true }

--- a/examples/text3d/Cargo.toml
+++ b/examples/text3d/Cargo.toml
@@ -12,5 +12,5 @@
   #=== DEPENDENCIES & FEATURES ===#
 
 [dependencies]
-  bevy       = { version = "0.18", default-features = true }
+  bevy       = { version = "0.19", default-features = true }
   bevy_lunex = { workspace = true }


### PR DESCRIPTION
This adds support for Bevy 0.19, but it should not be merged yet. It currently changes the dependency for bevy_rich_text3d to a custom branch that has not been merged yet, so this branch is blocked on that. Otherwise it fixes changes caused by upgrading Bevy. 